### PR TITLE
Notebook: Role Binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2021-02-16
+## Notebook: Role Binding [Jira Ticket](https://collaborate2.ons.gov.uk/jira/browse/CATDDSC-84)
+- Add a single binding for a service account to the created notebook instance and associated resources
+- New var to pass role id to the binding
+- Updated docs
+- Changed `service_account` variable from `service_account` to `service_account_email`
+
 ## [0.1.4] - 2021-02-02
 ## Remove Unnecessary Logic [Jira Ticket](https://collaborate2.ons.gov.uk/jira/browse/CATDDSC-52)
 - Removed unnecessary `count` expressions used for post startup script which is now executed regardless. ref **Notebook Git Config**

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ See: [Changelog](./CHANGELOG.md)
 | notebook\_network\_name | Optional: The name of the VPC to deploy this instance is in | `string` | `"notebook-vpc"` | no |
 | notebook\_sub\_network\_self\_link | Optional: The name of the subnet to deploy this instance is in | `string` | `""` | no |
 | project | Optional: The GCP project to deploy the notebook instance into | `string` | `""` | no |
-| service\_account | Optional: A service account within the same project to run the instance as | `string` | `""` | no |
+| role\_id | Optional: The role to assign to the notebook service account. **Note** Requires `service_account_email` to be specified | `string` | `""` | no |
+| service\_account\_email | Optional: The service account email to run the notebook instance as | `string` | `""` | no |
 | vm\_image\_image\_family | Optional: Use this VM image family to find the image; the newest image in this family will be used. See: [Notebook Images](https://cloud.google.com/ai-platform/deep-learning-vm/docs/images) | `string` | `"pytorch-latest-cpu"` | no |
 | vm\_image\_project | Optional: The name of the Google Cloud project that this VM image belongs to. Format: projects/{project\_id} | `string` | `"deeplearning-platform-release"` | no |
 | zone | Optional: The GCP zone to the deploy the note book instance into | `string` | `"europe-west2"` | no |
@@ -81,6 +82,27 @@ module "dans_r_notebook" {
 }
 ```
 
+Notebook with service account and role assigned to the notebook instance
+
+```terraform
+module "service_account_1_notebook" {
+  source                         = "github.com/ONSdigital/terraform-module-notebook"
+  name                           = "service-account-1-review-notebook"
+  notebook_network_name          = google_compute_network.network.name
+  notebook_sub_network_self_link = google_compute_subnetwork.subnet.self_link
+  service_account_email          = google_service_account.service_account_1.email
+  role_id                        = google_project_iam_custom_role.notebook_user_role.id
+
+  git_config = {
+    email = "service.account1@ons.gov.uk",
+    name  = "service account1"
+  }
+}
+```
+
+**Note**
+Terraform may complain about the role id not being computed at the time of apply. In which case you will need to deploy 
+The custom role first before the notebook using the role
 
 ```shell
 terraform init

--- a/iam.tf
+++ b/iam.tf
@@ -3,6 +3,17 @@ resource "google_storage_bucket_iam_binding" "notebook_gcs_binding" {
   bucket = google_storage_bucket.notebook_bucket.name
 
   members = [
-    "serviceAccount:${local.compute_engine_service_account}"
+    "serviceAccount:${local.compute_engine_service_account}",
+    "serviceAccount:${var.service_account_email}"
   ]
+}
+
+resource "google_notebooks_instance_iam_member" "notebook_instance_service_account_binding" {
+  count = length(var.role_id) > 0 ? 1 : 0
+
+  project       = google_notebooks_instance.notebook_instance_vm.project
+  location      = google_notebooks_instance.notebook_instance_vm.location
+  instance_name = google_notebooks_instance.notebook_instance_vm.name
+  role          = var.role_id
+  member        = "serviceAccount:${var.service_account_email}"
 }

--- a/notebook-instance.tf
+++ b/notebook-instance.tf
@@ -24,7 +24,7 @@ resource "google_notebooks_instance" "notebook_instance_vm" {
     type       = var.accelerator_config_type
   }
 
-  service_account = length(var.service_account) > 0 ? var.service_account : local.compute_engine_service_account
+  service_account = length(var.service_account_email) > 0 ? var.service_account_email : local.compute_engine_service_account
 
   install_gpu_driver = var.install_gpu_driver
 

--- a/review/main.tf
+++ b/review/main.tf
@@ -43,28 +43,110 @@ resource "google_compute_subnetwork" "subnet" {
   region        = "europe-west2"
 }
 
-module "davids_review_notebook" {
+resource "google_project_iam_custom_role" "notebook_user_role" {
+  role_id     = "notebookUserRole"
+  title       = "notebook-user-role"
+  description = "Role to allow AI Notebook user access"
+  permissions = [
+    "iam.serviceAccounts.actAs",
+    "compute.acceleratorTypes.list",
+    "compute.diskTypes.list",
+    "compute.instances.list",
+    "compute.machineTypes.list",
+    "compute.subnetworks.list",
+    "compute.instances.start",
+    "compute.instances.stop",
+    "notebooks.environments.get",
+    "notebooks.environments.getIamPolicy",
+    "notebooks.environments.list",
+    "notebooks.instances.get",
+    "notebooks.instances.getIamPolicy",
+    "notebooks.instances.list",
+    "notebooks.locations.get",
+    "notebooks.locations.list",
+    "notebooks.operations.get",
+    "notebooks.operations.list",
+    "notebooks.instances.update",
+    "notebooks.instances.start",
+    "notebooks.instances.stop"
+  ]
+}
+
+resource "google_service_account" "service_account_1" {
+  account_id   = "service-account-1"
+  display_name = "service-account-1"
+}
+
+resource "google_service_account" "service_account_2" {
+  account_id   = "service-account-2"
+  display_name = "service-account-2"
+}
+
+//resource "google_service_account_iam_member" "service_account_1_binding" {
+//  service_account_id = google_service_account.service_account_1.name
+//  role               = "roles/iam.serviceAccountUser"
+//  member             = "user:satya.bingumalla@ext.ons.gov.uk"
+//}
+
+resource "google_service_account_iam_member" "service_account_2_binding" {
+  service_account_id = google_service_account.service_account_2.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "user:"
+}
+
+resource "google_storage_bucket" "bucket_1" {
+  name = "project-${var.project}-bucket-1"
+
+  location                    = "EUROPE-WEST2"
+  force_destroy               = true
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket" "bucket_2" {
+  name = "project-${var.project}-bucket-2"
+
+  location                    = "EUROPE-WEST2"
+  force_destroy               = true
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_iam_member" "bucket_1_binding" {
+  bucket = google_storage_bucket.bucket_1.name
+  member = "serviceAccount:${google_service_account.service_account_1.email}"
+  role   = "roles/storage.objectCreator"
+}
+
+resource "google_storage_bucket_iam_member" "bucket_2_binding" {
+  bucket = google_storage_bucket.bucket_2.name
+  member = "serviceAccount:${google_service_account.service_account_2.email}"
+  role   = "roles/storage.objectCreator"
+}
+
+module "service_account_1_notebook" {
   source                         = "../"
-  name                           = "davids-review-notebook"
+  name                           = "service-account-1-review-notebook"
   notebook_network_name          = google_compute_network.network.name
   notebook_sub_network_self_link = google_compute_subnetwork.subnet.self_link
+  service_account_email          = google_service_account.service_account_1.email
+  role_id                        = google_project_iam_custom_role.notebook_user_role.id
 
   git_config = {
-    email = "david.pugh@ons.gov.uk",
-    name  = "David Pugh"
+    email = "service.account1@ons.gov.uk",
+    name  = "service account1"
   }
 }
 
-module "dans_review_notebook" {
+module "service_account_2_notebook" {
   source                         = "../"
-  name                           = "dans-review-notebook"
+  name                           = "service-account-2-review-notebook"
   vm_image_image_family          = "r-3-6-cpu-experimental"
   notebook_network_name          = google_compute_network.network.name
   notebook_sub_network_self_link = google_compute_subnetwork.subnet.self_link
+  service_account_email          = google_service_account.service_account_2.email
+  role_id                        = google_project_iam_custom_role.notebook_user_role.id
 
   git_config = {
-    email = "dan.melluish@ons.gov.uk",
-    name  = "Dan Melluish"
+    email = "service.account2@ons.gov.uk",
+    name  = "service account2"
   }
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -33,10 +33,10 @@ variable "vm_image_image_family" {
   description = "Optional: Use this VM image family to find the image; the newest image in this family will be used. See: https://cloud.google.com/ai-platform/deep-learning-vm/docs/images"
 }
 
-variable "service_account" {
+variable "service_account_email" {
   type        = string
   default     = ""
-  description = "Optional: A service account within the same project to run the instance as"
+  description = "Optional: The service account email to run the notebook instance as"
 }
 
 variable "install_gpu_driver" {
@@ -102,4 +102,10 @@ variable "labels" {
 variable "git_config" {
   type        = map(string)
   description = "Required: The notebook user's name and email address to set name and email in git config"
+}
+
+variable "role_id" {
+  type        = string
+  default     = ""
+  description = "Optional: The role to assign to the notebook service account. Requires `service_account_email` to be specified"
 }


### PR DESCRIPTION
[Jira Ticket](https://collaborate2.ons.gov.uk/jira/browse/CATDDSC-84)

Adds a binding to the provisioned notebook instance.  This is to introduce permission
boundaries between notebooks created with this module that reside within the same project.

- Add a single binding for a service account to the created notebook instance and associated resources
- New var to pass role id to the binding
- Updated docs

__To Review__

1. `git checkout djsd123/role-binding`
2. Enter your project name and your state bucket name in `review/main.tf`
3. Add a user account email (who does **NOT** inherit any permissions from any other groups to your project) to line **94** of `review/main.tf` 
3. `cd review && terraform init`
2. Run terraform i.e `terraform <plan/apply>`
3. Head over to the [Notebook console](https://console.cloud.google.com/ai/platform/notebooks/list/instances) and have the aforementioned user account browse to both  __JUPYTER_LAB__ instances. 
4. Result: `service-account-1-review-notebook` should result in a 403 and `service-account-2-review-notebook` should result with access to the __JUPYTER_LAB__ interface
5. Clear up; `terraform destroy` and `git checkout review/main.tf`