### PR TITLE
Z80dan/optional notebook gpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2021-03-01
+## Make GPU optional for new notebook [Jira Ticket](https://collaborate2.ons.gov.uk/jira/browse/CATDDSC-136)
+- Added new __OPTIONAL__ variable (`enable_gpu`) to allow a notebook to be created with or without a GPU
+
 ## [0.1.6] - 2021-02-25
 ## Create Python PyTorch notebooks for EH team [Jira Ticket](https://collaborate2.ons.gov.uk/jira/browse/CATDDSC-101)
 - Added new __OPTIONAL__ variable (`startup_script_path`) to allow a custom startup script to be specified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.1.7] - 2021-03-01
 ## Make GPU optional for new notebook [Jira Ticket](https://collaborate2.ons.gov.uk/jira/browse/CATDDSC-136)
-- Added new __OPTIONAL__ variable (`enable_gpu`) to allow a notebook to be created with or without a GPU
+- Added new __OPTIONAL__ variable (`enable_gpu`) to allow a notebook to be created with or without a GPU. 
+- Default value for __OPTIONAL__ variable (`install_gpu_driver`) is now false.
 
 ## [0.1.6] - 2021-02-25
 ## Create Python PyTorch notebooks for EH team [Jira Ticket](https://collaborate2.ons.gov.uk/jira/browse/CATDDSC-101)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See: [Changelog](./CHANGELOG.md)
 | data\_disk\_type | Optional: Boot disk type | `string` | `"DISK_TYPE_UNSPECIFIED"` | no |
 | enable\_gpu | Optional: Whether or not to enable GPU | `bool` | `false` | no  |
 | git\_config | Required: The notebook user's name and email address to set name and email in git config | `map(string)` | n/a | yes |
-| install\_gpu\_driver | Optional: Whether or not to install the GPU driver | `bool` | `true` | no |
+| install\_gpu\_driver | Optional: Whether or not to install the GPU driver | `bool` | `false` | no |
 | labels | Optional: Additional labels for the notebook | `map` | `{}` | no |
 | machine\_type | Optional: The machine type of the notebook instance. For other options, see: https://cloud.google.com/compute/docs/machine-types | `string` | `"n1-standard-1"` | no |
 | name | The name of the notebook instance | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ See: [Changelog](./CHANGELOG.md)
 | boot\_disk\_type | Optional: Boot disk type for notebook instance | `string` | `"PD_STANDARD"` | no |
 | data\_disk\_size\_gb | Optional:  The size in GB of the non-boot disk | `number` | `1` | no |
 | data\_disk\_type | Optional: Boot disk type | `string` | `"DISK_TYPE_UNSPECIFIED"` | no |
+| enable\_gpu | Optional: Whether or not to enable GPU | `bool` | `false` | no  |
 | git\_config | Required: The notebook user's name and email address to set name and email in git config | `map(string)` | n/a | yes |
 | install\_gpu\_driver | Optional: Whether or not to install the GPU driver | `bool` | `true` | no |
 | labels | Optional: Additional labels for the notebook | `map` | `{}` | no |

--- a/notebook-instance.tf
+++ b/notebook-instance.tf
@@ -19,14 +19,17 @@ resource "google_notebooks_instance" "notebook_instance_vm" {
     image_family = var.vm_image_image_family
   }
 
-  accelerator_config {
-    core_count = var.accelerator_config_core_count
-    type       = var.accelerator_config_type
+  dynamic "accelerator_config" {
+    for_each = var.enable_gpu ? [1] : []
+    content {
+      core_count = var.accelerator_config_core_count
+      type       = var.accelerator_config_type
+    }
   }
 
   service_account = length(var.service_account_email) > 0 ? var.service_account_email : local.compute_engine_service_account
 
-  install_gpu_driver = var.install_gpu_driver
+  install_gpu_driver = var.enable_gpu
 
   boot_disk_type    = var.boot_disk_type
   boot_disk_size_gb = var.boot_disk_size_gb
@@ -48,3 +51,4 @@ resource "google_notebooks_instance" "notebook_instance_vm" {
     proxy-mode = "service_account"
   }
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "service_account_email" {
 
 variable "install_gpu_driver" {
   type        = bool
-  default     = true
+  default     = false
   description = "Optional: Whether or not to install the GPU driver"
 }
 
@@ -114,4 +114,10 @@ variable "role_id" {
   type        = string
   default     = ""
   description = "Optional: The role to assign to the notebook service account. Requires `service_account_email` to be specified"
+}
+
+variable "enable_gpu" {
+  type        = bool
+  default     = false
+  description = "Optional: If set to true then the notebook will include a GPU"
 }


### PR DESCRIPTION
I've used a dynamic block to make GPU configuration optional. This seems an easier solution than duplicating the entire resource (as I found then you have to duplicate the iam bindings or add additional logic elsewhere). It start to get quite tangled.

Installing GPU drivers is now optional (to save installing them when not needed as that'll be the default case). There's an argument for tying enable_gpu and install_gpu_drivers together - if you want one you're more than likely to want the other!