### PR TITLE
Added goog-caip-notebook default label

### DIFF
--- a/notebook-instance.tf
+++ b/notebook-instance.tf
@@ -3,7 +3,7 @@ locals {
   compute_engine_service_account = "${data.google_project.notebook_project.number}-compute@developer.gserviceaccount.com"
   post_startup_script_url        = "${google_storage_bucket.notebook_bucket.url}/${google_storage_bucket_object.notebook_instance_post_startup_script.output_name}"
   required_labels = {
-    shutdown = "true"
+    shutdown           = "true"
     goog-caip-notebook = ""
   }
 }

--- a/notebook-instance.tf
+++ b/notebook-instance.tf
@@ -4,6 +4,7 @@ locals {
   post_startup_script_url        = "${google_storage_bucket.notebook_bucket.url}/${google_storage_bucket_object.notebook_instance_post_startup_script.output_name}"
   required_labels = {
     shutdown = "true"
+    goog-caip-notebook = ""
   }
 }
 


### PR DESCRIPTION
Fix for https://collaborate2.ons.gov.uk/jira/browse/CATDDSC-163

Tested with a local terraform plan against an existing notebook - no changes detected.