### PR TITLE
add shielded instance config and variable to enable secure boot

### DIFF
--- a/notebook-instance.tf
+++ b/notebook-instance.tf
@@ -9,7 +9,7 @@ locals {
 }
 
 resource "google_notebooks_instance" "notebook_instance_vm" {
-  provider = google-beta
+  provider = google
 
   name         = var.name
   location     = "${var.zone}-a"
@@ -18,6 +18,12 @@ resource "google_notebooks_instance" "notebook_instance_vm" {
   vm_image {
     project      = var.vm_image_project
     image_family = var.vm_image_image_family
+  }
+
+  shielded_instance_config {
+    enable_secure_boot = var.secure_boot
+    enable_integrity_monitoring = true
+    enable_vtpm = true
   }
 
   dynamic "accelerator_config" {

--- a/notebook-instance.tf
+++ b/notebook-instance.tf
@@ -21,9 +21,9 @@ resource "google_notebooks_instance" "notebook_instance_vm" {
   }
 
   shielded_instance_config {
-    enable_secure_boot = var.secure_boot
+    enable_secure_boot          = var.secure_boot
     enable_integrity_monitoring = true
-    enable_vtpm = true
+    enable_vtpm                 = true
   }
 
   dynamic "accelerator_config" {

--- a/variables.tf
+++ b/variables.tf
@@ -133,3 +133,9 @@ variable "disable_downloads" {
   default     = false
   description = "Optional: If set to true the download option will be disabled"
 }
+
+variable "secure_boot" {
+  type        = bool
+  default     = false
+  description = "Optional: If set to true secure boot will we enabled"
+}


### PR DESCRIPTION
- change to use the "google" provider as "google-beta" does not work for shielded instance config
- add shielded_instance_config and use the default values so that no changes should happen in projects using this module until the "secure_boot" variable is set to true