### PR TITLE
disable project wide ssh keys for accessing notebooks

### DIFF
--- a/notebook-instance.tf
+++ b/notebook-instance.tf
@@ -55,13 +55,13 @@ resource "google_notebooks_instance" "notebook_instance_vm" {
   labels = merge(local.required_labels, var.labels)
 
   metadata = (
-  var.disable_downloads && var.block_project_wide_ssh_keys ? #Check both of these together to not force rebuild of existing notebooks
-  {
-    terraform                  = "true"
-    proxy-mode                 = "service_account"
-    notebook-disable-downloads = true
-    block-project-ssh-keys     = true
-  } :
+    var.disable_downloads && var.block_project_wide_ssh_keys ? #Check both of these together to not force rebuild of existing notebooks
+    {
+      terraform                  = "true"
+      proxy-mode                 = "service_account"
+      notebook-disable-downloads = true
+      block-project-ssh-keys     = true
+    } :
     var.disable_downloads ?
     {
       terraform                  = "true"

--- a/notebook-instance.tf
+++ b/notebook-instance.tf
@@ -55,12 +55,18 @@ resource "google_notebooks_instance" "notebook_instance_vm" {
   labels = merge(local.required_labels, var.labels)
 
   metadata = (
+  var.disable_downloads && var.block_project_wide_ssh_keys ? #Check both of these together to not force rebuild of existing notebooks
+  {
+    terraform                  = "true"
+    proxy-mode                 = "service_account"
+    notebook-disable-downloads = true
+    block-project-ssh-keys     = true
+  } :
     var.disable_downloads ?
     {
       terraform                  = "true"
       proxy-mode                 = "service_account"
       notebook-disable-downloads = true
-      block-project-ssh-keys     = true #Added to disable downloads block as all notebooks with downloads disabled should also have this set
     } :
     {
       terraform  = "true"

--- a/notebook-instance.tf
+++ b/notebook-instance.tf
@@ -60,6 +60,7 @@ resource "google_notebooks_instance" "notebook_instance_vm" {
       terraform                  = "true"
       proxy-mode                 = "service_account"
       notebook-disable-downloads = true
+      block-project-ssh-keys     = true #Added to disable downloads block as all notebooks with downloads disabled should also have this set
     } :
     {
       terraform  = "true"

--- a/variables.tf
+++ b/variables.tf
@@ -139,3 +139,9 @@ variable "secure_boot" {
   default     = false
   description = "Optional: If set to true secure boot will we enabled"
 }
+
+variable "block_project_wide_ssh_keys" {
+  type        = bool
+  default     = false
+  description = "Optional: If set to true project wide ssh keys will be blocked"
+}


### PR DESCRIPTION
disable project-wide ssh keys for all notebooks with downloads disabled as this is only being set on new notebooks currently and will be rolled out to all notebooks in the future.